### PR TITLE
Give core project a meaningful name in Android Studio

### DIFF
--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,1 +1,3 @@
+rootProject.name = 'ViroCORE'
+
 include ':app', ':libs:gvr', ':libs:arcore', ':renderertest', ':memoryleaktest', ':virocore', ':viroreact', ':viroar', ':releasetest', ':nativetest'


### PR DESCRIPTION
It's about to change this name 
![image](https://user-images.githubusercontent.com/3314607/98907359-ff448980-24be-11eb-8691-91143fcf8d3a.png)

When every repo is called `android` , you don't know which one it is