### PR TITLE
Remove remaining suspension in Android

### DIFF
--- a/android/app/src/main/cpp/VROSceneRendererOVR.cpp
+++ b/android/app/src/main/cpp/VROSceneRendererOVR.cpp
@@ -899,8 +899,6 @@ typedef struct
     // Viro parameters
     std::shared_ptr<VRORenderer> vroRenderer;
     std::shared_ptr<VRODriverOpenGLAndroid> driver;
-    bool                suspended;
-    double              suspendedNotificationTime;
 } ovrApp;
 
 static void ovrApp_Clear( ovrApp * app )
@@ -916,8 +914,6 @@ static void ovrApp_Clear( ovrApp * app )
     app->BackButtonDown = false;
     app->BackButtonDownStartTime = 0.0;
     app->UseMultiview = true;
-    app->suspended = false;
-    app->suspendedNotificationTime = VROTimeCurrentSeconds();
     ovrEgl_Clear( &app->Egl );
     ovrRenderer_Clear( &app->Renderer );
 }
@@ -1265,7 +1261,6 @@ enum
     MESSAGE_ON_SURFACE_DESTROYED,
     MESSAGE_ON_KEY_EVENT,
     MESSAGE_ON_TOUCH_EVENT,
-    MESSAGE_SUSPEND,
     MESSAGE_RECENTER_TRACKING
 };
 
@@ -1358,7 +1353,6 @@ void * AppThreadFunction( void * parm )
                                                                                ovrMessage_GetIntegerParm( &message, 0 ),
                                                                                ovrMessage_GetFloatParm( &message, 1 ),
                                                                                ovrMessage_GetFloatParm( &message, 2 ) ); break; }
-                case MESSAGE_SUSPEND:               {appState.suspended = ovrMessage_GetIntegerParm( &message, 0); break; }
                 case MESSAGE_RECENTER_TRACKING:     {if (appState.Ovr) vrapi_RecenterPose(appState.Ovr); break;}
             }
 
@@ -1373,16 +1367,6 @@ void * AppThreadFunction( void * parm )
 
         if ( appState.Ovr == NULL )
         {
-            continue;
-        }
-
-        if ( appState.suspended ) {
-            double newTime = VROTimeCurrentSeconds();
-            // notify the user about bad keys 5 times a second (every 200ms/.2s)
-            if (newTime - appState.suspendedNotificationTime > .2) {
-                perr("Renderer suspended! Do you have a valid key?");
-                appState.suspendedNotificationTime = newTime;
-            }
             continue;
         }
 

--- a/macos/ViroKit/VROViewScene.mm
+++ b/macos/ViroKit/VROViewScene.mm
@@ -37,7 +37,6 @@ static VROVector3f const kZeroVector = VROVector3f();
     std::queue<std::function<void()>> _taskQueue;
     
     int _frame;
-    double _suspendedNotificationTime;
 }
 
 @end
@@ -113,7 +112,6 @@ static CVReturn VRODisplayLinkCallback(CVDisplayLinkRef displayLink, const CVTim
     
     _driver = std::make_shared<VRODriverOpenGLMacOS>(_openGLContext, _pixelFormat);
     _frame = 0;
-    _suspendedNotificationTime = VROTimeCurrentSeconds();
     _inputController = std::make_shared<VROInputControllerAR>(self.frame.size.width,
                                                               self.frame.size.height,
                                                               _driver);

--- a/wasm/src/cpp/VROViewScene.cpp
+++ b/wasm/src/cpp/VROViewScene.cpp
@@ -47,7 +47,6 @@ VROViewScene::VROViewScene(VRORendererTestType test) :
     
     _driver = std::make_shared<VRODriverOpenGLWasm>();
     _frame = 0;
-    _suspendedNotificationTime = 0;//VROTimeCurrentSeconds();
     _inputController = std::make_shared<VROInputControllerWasm>(_driver);
     
     VRORendererConfiguration config;

--- a/wasm/src/cpp/VROViewScene.h
+++ b/wasm/src/cpp/VROViewScene.h
@@ -33,7 +33,6 @@ private:
     
     int _frame;
     int _width, _height;
-    float _suspendedNotificationTime;
     
     float _angle;
     


### PR DESCRIPTION
This removes code that is a leftover from the time when viro required an API key and was not open sourced.
This PR fixes the issue reported here:

https://discord.com/channels/774471080713781259/774474909731782666/876813424884068393