### PR TITLE
Release from CI

### DIFF
--- a/.github/changelog-configuration.json
+++ b/.github/changelog-configuration.json
@@ -1,0 +1,32 @@
+{
+  "categories": [
+    {
+      "title": "## 🚀 Features",
+      "labels": [
+        "feature",
+        "enhancement"
+      ]
+    },
+    {
+      "title": "## 🐛 Fixes",
+      "labels": [
+        "fix",
+        "bug"
+      ]
+    },
+    {
+      "title": "## 💬 Maintenance",
+      "labels": [
+        "maintenance"
+      ]
+    }
+  ],
+  "ignore_labels": [
+    "dependencies",
+    "gradle-wrapper"
+  ],
+  "sort": "ASC",
+  "template": "${{CHANGELOG}}",
+  "pr_template": "- ${{TITLE}}\n   - PR: #${{NUMBER}}",
+  "empty_template": "- no changes"
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,60 @@
+name: Changelog vs Release
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 0
+
+      - name: Build Changelog
+        id: github_release
+        uses: mikepenz/release-changelog-builder-action@main
+        with:
+          configuration: ".github/changelog-configuration.json"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install JDK ${{ matrix.java_version }}
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: 11
+
+      - name: Install Android SDK
+        uses: malinskiy/action-android/install-sdk@release/0.1.2
+
+      - name: Build project
+        run: ./gradlew assembleRelease
+        working-directory: ./android
+        env:
+          VERSION: ${{ github.ref }}
+
+      - name: Get the version
+        id: tagger
+        uses: jimschubert/query-tag-action@v2
+        with:
+          skip-unshallow: 'true'
+          abbrev: false
+          commit-ish: HEAD
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ github.ref }}
+          name: ${{steps.tagger.outputs.tag}}
+          body: ${{steps.github_release.outputs.changelog}}
+          files: |
+            android/virocore/build/outputs/aar/virocore-release*.aar
+            android/viroar/build/outputs/aar/viro*.aar
+            android/viroreact/build/outputs/aar/viro*.aar
+            android/app/build/outputs/aar/*.aar
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
By setting a new tag, it creates a new release in github->releases.
Please see a development example here https://github.com/hannesa2/virocoreCommunity/releases/tag/refs%2Ftags%2F0.3

Additionally you can set label to add pull request to changelog in release, please see this (unrelated) sample https://github.com/MikeOrtiz/TouchImageView/releases/tag/refs%2Ftags%2F3.1.0 

#### Changelog labels are:
* feature
* enhancement
* fix
* bug
* maintenance