### PR TITLE
Fix release url

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,8 +34,6 @@ jobs:
       - name: Build project
         run: ./gradlew assembleRelease
         working-directory: ./android
-        env:
-          VERSION: ${{ github.ref }}
 
       - name: Get the version
         id: tagger
@@ -48,7 +46,7 @@ jobs:
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
-          tag_name: ${{ github.ref }}
+          tag_name: ${{steps.tagger.outputs.tag}}
           name: ${{steps.tagger.outputs.tag}}
           body: ${{steps.github_release.outputs.changelog}}
           files: |


### PR DESCRIPTION
Release mail comes with
https://github.com/ViroCommunity/virocore/releases/tag/refs%2Ftags%2Frc-1.20.1
there are aar as assets included

but click on release here https://github.com/ViroCommunity/virocore/releases
the url is
https://github.com/ViroCommunity/virocore/releases/tag/rc-1.20.1
there are **no** aar as assets included

This pull request will solve it. To test it, please create a new tag again after merge
