### PR TITLE
Fix For presses not working in iOS

### DIFF
--- a/ios/ViroKit/VROViewAR.mm
+++ b/ios/ViroKit/VROViewAR.mm
@@ -291,7 +291,8 @@ static VROVector3f const kZeroVector = VROVector3f();
 }
 
 - (void)handleRotate:(UIRotationGestureRecognizer *)recognizer {
-    CGPoint location = [recognizer locationInView:recognizer.view];
+    // locationInView was `recognizer.self` but if view is created after app initialization, then it location x and y is 0
+    CGPoint location = [recognizer locationInView:nil];
     VROVector3f viewportTouchPos = VROVector3f(location.x * self.contentScaleFactor, location.y * self.contentScaleFactor);
     
     if(recognizer.state == UIGestureRecognizerStateBegan) {
@@ -305,7 +306,8 @@ static VROVector3f const kZeroVector = VROVector3f();
 }
 
 - (void)handlePinch:(UIPinchGestureRecognizer *)recognizer {
-    CGPoint location = [recognizer locationInView:recognizer.view];
+    // locationInView was `recognizer.self` but if view is created after app initialization, then it location x and y is 0
+    CGPoint location = [recognizer locationInView:nil];
     VROVector3f viewportTouchPos = VROVector3f(location.x * self.contentScaleFactor, location.y * self.contentScaleFactor);
   
     if(recognizer.state == UIGestureRecognizerStateBegan) {
@@ -318,7 +320,8 @@ static VROVector3f const kZeroVector = VROVector3f();
 }
 
 - (void)handleLongPress:(UIPanGestureRecognizer *)recognizer {
-    CGPoint location = [recognizer locationInView:recognizer.view];
+    // locationInView was `recognizer.self` but if view is created after app initialization, then it location x and y is 0
+    CGPoint location = [recognizer locationInView:nil];
     
     VROVector3f viewportTouchPos = VROVector3f(location.x * self.contentScaleFactor, location.y * self.contentScaleFactor);
     
@@ -332,7 +335,8 @@ static VROVector3f const kZeroVector = VROVector3f();
 }
 
 - (void)handleTap:(UITapGestureRecognizer *)recognizer {
-    CGPoint location = [recognizer locationInView:recognizer.view];
+    // locationInView was `recognizer.self` but if view is created after app initialization, then it location x and y is 0
+    CGPoint location = [recognizer locationInView:nil];
     
     VROVector3f viewportTouchPos = VROVector3f(location.x * self.contentScaleFactor, location.y * self.contentScaleFactor);
     


### PR DESCRIPTION
I'm throwing this out there because there has been an issue in react-viro for a while where if viro is loaded in a react-native project, and then unloaded and then reloaded, presses don't work on iOS. They are offset because the screen dimensions read as zero. 

I tracked it down to this file, but have no C++ experience, and just hacked this together, so there is probably a better way. Just wanted to create this pr as a jumping off point.