### PR TITLE
Reduce CI builds

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -22,7 +22,7 @@ jobs:
           ./gradlew assembleDebug
         working-directory: ./android
       - name: Upload result ViroCore
-        uses: actions/upload-artifact@v2.2.4
+        uses: actions/upload-artifact@v3.1.0
         with:
           name: viroCore
           path: |
@@ -49,7 +49,7 @@ jobs:
       - name: Code checks
         run: ./gradlew check
       - name: Archive Lint report
-        uses: actions/upload-artifact@v2.2.4
+        uses: actions/upload-artifact@v3.1.0
         if: ${{ always() }}
         with:
           name: Viro-Lint-report
@@ -87,7 +87,7 @@ jobs:
             IPHONEOS_DEPLOYMENT_TARGET=9.0
 
       - name: Upload iOS Renderer artifact
-        uses: actions/upload-artifact@v2.2.4
+        uses: actions/upload-artifact@v3.1.0
         with:
           name: ios_dist.tgz
           path: ./ios/dist/

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -62,7 +62,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        xcode: [ '12.5.1', '13.1.0', '13.2.0' ]
+        xcode: [ '12.5.1', '13.2.1' ]
         macOS: [ 'macOS-11' ]
     steps:
       - uses: actions/checkout@v2.4.0


### PR DESCRIPTION
XCode `13.2.0` is no more supported.
This will fix most of the dependabot pull requests