### PR TITLE
small fix to align objects for eyes on oculus

### DIFF
--- a/android/sharedCode/src/main/cpp/VROSceneRendererOVR.cpp
+++ b/android/sharedCode/src/main/cpp/VROSceneRendererOVR.cpp
@@ -819,6 +819,9 @@ static void ovrRenderer_RenderFrame(ovrRenderer *rendererOVR, const ovrJava *jav
             viroHeadView[i] += ovrEyeView[i];
         } //After these additions, viroHeadView is really viroEyeView
 
+        const float eyeOffset = ( eye ? -5.0f : 5.0f ) * interpupillaryDistance;
+        viroHeadView.translate(VROVector3f(eyeOffset,0.0f,0.0f));
+
         // We use our projection matrix because the one computed by OVR appears to be identical for
         // left and right, but with fixed NCP and FCP. Our projection uses the correct NCP and FCP.
         renderer->renderEye(eyeType,


### PR DESCRIPTION
the objects shown in the eyes on the oculus did not look like a single object. Here is a small fix that aligns the objects.